### PR TITLE
Fix use FILE_LINK_INFORMATION struct for (fileInfoClass == FileLinkIn…

### DIFF
--- a/filesys/miniFilter/simrep/simrep.c
+++ b/filesys/miniFilter/simrep/simrep.c
@@ -1958,7 +1958,7 @@ Return Value:
 
      } else if (fileInfoClass == FileLinkInformation) {
 
-        bufferLength = FIELD_OFFSET( FILE_RENAME_INFORMATION, FileName ) + newFileName.Length;
+        bufferLength = FIELD_OFFSET( FILE_LINK_INFORMATION, FileName ) + newFileName.Length;
 
         buffer = ExAllocatePoolWithTag( PagedPool, bufferLength, SIMREP_STRING_TAG );
 


### PR DESCRIPTION

Fix use FILE_LINK_INFORMATION struct for (fileInfoClass == FileLinkInformation) instead of FILE_RENAME_INFORMATION struct.

There was no error because both structs are same size, but this may change in future versions.
